### PR TITLE
Use root index.d.ts for main lib

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.4.1",
   "description": "Javascript API to access Keva ElectrumX server through Websocket",
   "main": "dist/index.js",
-  "types": "dist/types/index.d.ts",
+  "types": "dist/index.d.ts",
   "scripts": {
     "test": "jest",
     "dev": "jest --watch",


### PR DESCRIPTION
## :clipboard:  PR summary

I was attempting to implement the new keva library into my own extension, but I was getting an error (see screenshots) about improper/unepected types. I know this was a bad type root as the websocket class is 100% WORKING and I can console log the results.

## :gear: How to test
- Hard to test, but you may try running `npm link` or similar `yarn link` to override `keva-api-js`
- After this, add `keva-api-js` to a fresh js project and copy the same code example from #2 .
- You should no longer see the error

## :notebook: Notes
This may actually be a feature, but now that we can use the correct type root, you are strongly pushed to import the TypeScript-only `Keva` type namespace separately by doing the following -

```ts
import KevaWS  from 'keva-api-js'
import type { Keva } from 'keva-api-js/types'`
```

vs all in one -

```ts
import KevaWS, { Keva } from 'keva-api-js'
```

## :bug: Issues
Fixes #2 